### PR TITLE
Fix incorrect mapping of a1 square in algebraic coordinates

### DIFF
--- a/Sources/ChessboardKit/ChessboardKit.swift
+++ b/Sources/ChessboardKit/ChessboardKit.swift
@@ -485,7 +485,7 @@ public struct Chessboard: View {
     }
     
     func rowLabelView(row: Int) -> some View {
-        let displayRow = chessboardModel.shouldFlipBoard ? row : (7 - row)
+        let displayRow = chessboardModel.shouldFlipBoard ? (7 - row) : row
         let labelSize = chessboardModel.size / 32
         let squareSize = chessboardModel.size / 8
         


### PR DESCRIPTION
This PR fixes an incorrect algebraic coordinate mapping where the lower-left square from White’s perspective was labeled h1 instead of a1. The issue was caused by the displayRow calculation in ChessboardKit.swift (line 488). I corrected the true/false branch of the ternary expression so row inversion is applied in the proper orientation. The fix is a single-line change.  This is a great package, by the way!  Thanks for sharing!