### PR TITLE
Disable hit testing on legalMoveHighlightsView.

### DIFF
--- a/Sources/ChessboardKit/ChessboardKit.swift
+++ b/Sources/ChessboardKit/ChessboardKit.swift
@@ -561,6 +561,7 @@ public struct Chessboard: View {
                               y: chessboardModel.size / 16 + chessboardModel.size / 8 * CGFloat(chessboardModel.shouldFlipBoard ? square.row : 7 - square.row))
             }
         }
+        .allowsHitTesting(false)
     }
     
     public func onMove(_ callback: @escaping (Move, Bool, String, String, String, PieceKind?) -> Void) -> Chessboard {


### PR DESCRIPTION
ChessboardKit.swift:554-565 now applies .allowsHitTesting(false) to legalMoveHighlightsView, so clicking/tapping a highlighted destination square triggers the existing tap-to-move logic instead of the overlay swallowing the touch.